### PR TITLE
Issue #118 - Add cron bundle to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Database client version: libmysql - 10.1.26-MariaDB
 PHP version: 7.0
 ```
 
+A CRON bundle was installed to help run CRON tasks in the production enviroment. To create a cron job, run:
+```
+docker-compose exec php bash
+php bin/console cron:create
+```
+The following commands fro sending emails are available:
+- `email:delete:obsolete-registrations` - Deletes expired unclaimed registrations from the database, emptying space for other attendees.
+- `email:send:attendee-notification` - Sends reminders to all attendees that an upcoming event is nearing. Should be executed at least once a day.
+- `email:send:organizer-notification` - Sends information about registered users to organizers. Should be executed once a day.
+- `email:send:registration-open` - Sends notifications that a new event has become available for registration. Should be executed at least once a day.
+
+Setting up CRON tasks has to be done manually, either using CRON externally or using the CRON package avialble here: https://github.com/Cron/Cron
+
+To install and setup, just follow the provided instructions on the CRON github page.
+
 ## Running the tests
 ```
 docker-compose exec php php vendor/phpunit/phpunit/phpunit

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The following commands fro sending emails are available:
 
 Setting up CRON tasks has to be done manually, either using CRON externally or using the CRON package avialble here: https://github.com/Cron/Cron
 
+The commands **have** to be executed from the bin folder.
+
 To install and setup, just follow the provided instructions on the CRON github page.
 
 ## Running the tests

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ A CRON bundle was installed to help run CRON tasks in the production enviroment.
 docker-compose exec php bash
 php bin/console cron:create
 ```
-The following commands fro sending emails are available:
+The following commands for sending emails are available:
 - `email:delete:obsolete-registrations` - Deletes expired unclaimed registrations from the database, emptying space for other attendees.
 - `email:send:attendee-notification` - Sends reminders to all attendees that an upcoming event is nearing. Should be executed at least once a day.
 - `email:send:organizer-notification` - Sends information about registered users to organizers. Should be executed once a day.
 - `email:send:registration-open` - Sends notifications that a new event has become available for registration. Should be executed at least once a day.
 
-Setting up CRON tasks has to be done manually, either using CRON externally or using the CRON package avialble here: https://github.com/Cron/Cron
+Setting up CRON tasks has to be done manually, either using CRON externally or using the CRON package available here: https://github.com/Cron/Cron
 
-The commands **have** to be executed from the bin folder.
+The commands **have to** be executed from the bin folder.
 
 To install and setup, just follow the provided instructions on the CRON github page.
 

--- a/src/app/AppKernel.php
+++ b/src/app/AppKernel.php
@@ -17,6 +17,7 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+            new Cron\CronBundle\CronCronBundle(),
             new AppBundle\AppBundle(),
             new AdminBundle\AdminBundle(),
             new EmailBundle\EmailBundle(),

--- a/src/app/DoctrineMigrations/Version20180212204617.php
+++ b/src/app/DoctrineMigrations/Version20180212204617.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180212204617 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE cron_job (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(191) NOT NULL, command VARCHAR(191) NOT NULL, schedule VARCHAR(191) NOT NULL, description VARCHAR(191) NOT NULL, enabled TINYINT(1) NOT NULL, UNIQUE INDEX un_name (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE cron_report (id INT AUTO_INCREMENT NOT NULL, job_id INT DEFAULT NULL, run_at DATETIME NOT NULL, run_time DOUBLE PRECISION NOT NULL, exit_code INT NOT NULL, output LONGTEXT NOT NULL, INDEX IDX_B6C6A7F5BE04EA9 (job_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE cron_report ADD CONSTRAINT FK_B6C6A7F5BE04EA9 FOREIGN KEY (job_id) REFERENCES cron_job (id)');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE cron_report DROP FOREIGN KEY FK_B6C6A7F5BE04EA9');
+        $this->addSql('DROP TABLE cron_job');
+        $this->addSql('DROP TABLE cron_report');
+    }
+}

--- a/src/composer.json
+++ b/src/composer.json
@@ -24,6 +24,7 @@
     },
     "require": {
         "php": ">=5.5.9",
+        "cron/cron-bundle": "^1.2",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-migrations-bundle": "^1.0",
         "doctrine/orm": "^2.5",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ee68c31cbb8bcfe5deccb94529f5d0e",
+    "content-hash": "012b01efe1068037e83a9c3c9381b0c2",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -105,6 +105,100 @@
                 "tls"
             ],
             "time": "2017-11-29T09:37:33+00:00"
+        },
+        {
+            "name": "cron/cron",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Cron/Cron.git",
+                "reference": "9e4e736ce589b0a4e82c327f9e48516d8f4dc619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Cron/Cron/zipball/9e4e736ce589b0a4e82c327f9e48516d8f4dc619",
+                "reference": "9e4e736ce589b0a4e82c327f9e48516d8f4dc619",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5|^7.0",
+                "symfony/process": "^2.4|^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cron\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dries De Peuter",
+                    "email": "dries@nousefreak.be"
+                }
+            ],
+            "description": "Cronjobs",
+            "time": "2017-08-31T05:05:07+00:00"
+        },
+        {
+            "name": "cron/cron-bundle",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Cron/Symfony-Bundle.git",
+                "reference": "71cdf2e37bacab069b4555228aa5a831c33db7da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Cron/Symfony-Bundle/zipball/71cdf2e37bacab069b4555228aa5a831c33db7da",
+                "reference": "71cdf2e37bacab069b4555228aa5a831c33db7da",
+                "shasum": ""
+            },
+            "require": {
+                "cron/cron": "^1.0.1",
+                "doctrine/doctrine-bundle": "^1.3",
+                "doctrine/orm": "^2.4",
+                "php": ">=5.5.0",
+                "symfony/framework-bundle": "^2.5|^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0",
+                "symfony/symfony": "^2.4|^3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cron\\CronBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dries De Peuter",
+                    "email": "dries@nousefreak.be"
+                }
+            ],
+            "description": "Symfony cron",
+            "time": "2018-01-25T07:47:34+00:00"
         },
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
Ok.. toto je zvlastne. Bude treba pridat popis do rozbehavania s tadeto: https://github.com/Cron/Symfony-Bundle#installation
Joby sa registruju cez cron:create a potom sa v crone vola cron:run